### PR TITLE
Ported to the new metaboss_utils that doesn't submit the transactions automatically.

### DIFF
--- a/crates/cmds-solana/Cargo.toml
+++ b/crates/cmds-solana/Cargo.toml
@@ -39,7 +39,7 @@ bs58 = "0.4"
 
 value = { path = "../value", version = "0.0.1" }
 flow-lib = { path = "../flow-lib", version = "0.0.1" }
-metaboss_utils = { git = "https://github.com/space-operator/metaboss_utils.git", rev = "9f237fd10b6e5478bf7fd395482d58b71fe2811a" }
+metaboss_utils = { git = "https://github.com/space-operator/metaboss_utils.git", branch = "return-transactions" }
 
 [dev-dependencies]
 rust_decimal_macros = "1.26"

--- a/crates/cmds-solana/Cargo.toml
+++ b/crates/cmds-solana/Cargo.toml
@@ -39,7 +39,10 @@ bs58 = "0.4"
 
 value = { path = "../value", version = "0.0.1" }
 flow-lib = { path = "../flow-lib", version = "0.0.1" }
-metaboss_utils = { git = "https://github.com/space-operator/metaboss_utils.git", branch = "return-transactions" }
+
+[dependencies.metaboss_utils]
+git = "https://github.com/space-operator/metaboss_utils.git"
+rev = "5bc91d67f84a3f7ec609c63a0cd4cd83c6018a0f"
 
 [dev-dependencies]
 rust_decimal_macros = "1.26"

--- a/crates/cmds-solana/src/metaboss/burn_print.rs
+++ b/crates/cmds-solana/src/metaboss/burn_print.rs
@@ -73,12 +73,17 @@ impl CommandTrait for BurnPrint {
 
         let args = BurnPrintArgs {
             client: &ctx.solana_client,
-            keypair: Arc::new(input.keypair),
+            keypair: Arc::new(input.keypair.clone_keypair()),
             mint_pubkey: input.mint_account_pubkey,
             master_mint_pubkey: input.master_mint_pubkey,
         };
 
-        let sig = burn_print(args).await.map_err(crate::Error::custom)?;
+        let mut tx = burn_print(args).await.map_err(crate::Error::custom)?;
+
+        let recent_blockhash = ctx.solana_client.get_latest_blockhash().await?;
+        try_sign_wallet(&ctx, &mut tx, &[&input.keypair], recent_blockhash).await?;
+
+        let sig = submit_transaction(&ctx.solana_client, tx).await?;
 
         Ok(value::to_map(&Output { signature: sig })?)
     }

--- a/crates/cmds-solana/src/metaboss/primary_sale_happened.rs
+++ b/crates/cmds-solana/src/metaboss/primary_sale_happened.rs
@@ -64,13 +64,18 @@ impl CommandTrait for PrimarySaleHappened {
 
         let args = SetPrimarySaleHappenedArgs {
             client: &ctx.solana_client,
-            keypair: Arc::new(input.keypair),
+            keypair: Arc::new(input.keypair.clone_keypair()),
             mint_account: input.mint_account,
         };
 
-        let sig = set_primary_sale_happened(&args)
+        let mut tx = set_primary_sale_happened(&args)
             .await
             .map_err(crate::Error::custom)?;
+
+        let recent_blockhash = ctx.solana_client.get_latest_blockhash().await?;
+        try_sign_wallet(&ctx, &mut tx, &[&input.keypair], recent_blockhash).await?;
+
+        let sig = submit_transaction(&ctx.solana_client, tx).await?;
 
         Ok(value::to_map(&Output { signature: sig })?)
     }

--- a/crates/cmds-solana/src/metaboss/set_immutable.rs
+++ b/crates/cmds-solana/src/metaboss/set_immutable.rs
@@ -64,11 +64,16 @@ impl CommandTrait for SetImmutable {
 
         let args = SetImmutableArgs {
             client: &ctx.solana_client,
-            keypair: Arc::new(input.keypair),
+            keypair: Arc::new(input.keypair.clone_keypair()),
             mint_account: input.mint_account,
         };
 
-        let sig = set_immutable(args).await.map_err(crate::Error::custom)?;
+        let mut tx = set_immutable(args).await.map_err(crate::Error::custom)?;
+
+        let recent_blockhash = ctx.solana_client.get_latest_blockhash().await?;
+        try_sign_wallet(&ctx, &mut tx, &[&input.keypair], recent_blockhash).await?;
+
+        let sig = submit_transaction(&ctx.solana_client, tx).await?;
 
         Ok(value::to_map(&Output { signature: sig })?)
     }

--- a/crates/cmds-solana/src/metaboss/update/name.rs
+++ b/crates/cmds-solana/src/metaboss/update/name.rs
@@ -70,14 +70,19 @@ impl CommandTrait for UpdateName {
     async fn run(&self, ctx: Context, inputs: ValueSet) -> Result<ValueSet, CommandError> {
         let input: Input = value::from_map(inputs)?;
 
-        let sig = update_name(
+        let mut tx = update_name(
             &ctx.solana_client,
-            input.keypair,
+            input.keypair.clone_keypair(),
             &input.mint_account,
             &input.name,
         )
         .await
         .map_err(crate::Error::custom)?;
+
+        let recent_blockhash = ctx.solana_client.get_latest_blockhash().await?;
+        try_sign_wallet(&ctx, &mut tx, &[&input.keypair], recent_blockhash).await?;
+
+        let sig = submit_transaction(&ctx.solana_client, tx).await?;
 
         Ok(value::to_map(&Output { signature: sig })?)
     }

--- a/crates/cmds-solana/src/metaboss/update/symbol.rs
+++ b/crates/cmds-solana/src/metaboss/update/symbol.rs
@@ -70,14 +70,19 @@ impl CommandTrait for UpdateSymbol {
     async fn run(&self, ctx: Context, inputs: ValueSet) -> Result<ValueSet, CommandError> {
         let input: Input = value::from_map(inputs)?;
 
-        let sig = update_symbol(
+        let mut tx = update_symbol(
             &ctx.solana_client,
-            input.keypair,
+            input.keypair.clone_keypair(),
             &input.mint_account,
             &input.symbol,
         )
         .await
         .map_err(crate::Error::custom)?;
+
+        let recent_blockhash = ctx.solana_client.get_latest_blockhash().await?;
+        try_sign_wallet(&ctx, &mut tx, &[&input.keypair], recent_blockhash).await?;
+
+        let sig = submit_transaction(&ctx.solana_client, tx).await?;
 
         Ok(value::to_map(&Output { signature: sig })?)
     }


### PR DESCRIPTION
- [x] Now the transaction handling is done in the `space-operator`
- [x] We sign wallets before submitting, which is the reason for move.